### PR TITLE
Feature/sim 1314/new gal sim patch

### DIFF
--- a/ups/GalSim.cfg
+++ b/ups/GalSim.cfg
@@ -3,7 +3,7 @@
 import lsst.sconsUtils
 
 dependencies = {
-    "required": [],
+    "required": ["tmv", "numpy", "boost", "fftw"],
 }
 
 config = lsst.sconsUtils.ExternalConfiguration(

--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,7 +1,15 @@
 export SCONSFLAGS=$SCONSFLAGS" USE_UNKNOWN_VARS=true TMV_DIR="$TMV_DIR" PREFIX="$PREFIX" PYPREFIX="$PREFIX"/lib/python EXTRA_LIB_PATH="$TMV_DIR"/lib EXTRA_INCLUDE_PATH="$TMV_DIR"/include"
 
+pathToPython=$(which python)
+export DYLD_FALLBACK_LIBRARY_PATH="${pathToPython%bin/python}/lib"
+
 install()
 {
     default_install
     cp -r include $PREFIX/
+
+    if [[ $OSTYPE == darwin* ]]; then
+        install_name_tool -add_rpath $DYLD_FALLBACK_LIBRARY_PATH "$PREFIX"/lib/python/galsim/_galsim.so
+        install_name_tool -change libpython2.7.dylib @rpath/libpython2.7.dylib "$PREFIX"/lib/python/galsim/_galsim.so
+    fi
 }


### PR DESCRIPTION
Up until now, we have been dealing with the fact that GalSim cannot build against anaconda's libpython2.7.dylib by having newinstall.sh use install_name_tool to change the install_name in that library from a relative to an absolute path.  This works, but as soon as the user runs conda update on their anaconda, the patch is undone.

This pull request adopts a more permanent solution by changing the install_names in the modules that load libpython2.7.dylib such that they can always find it.  This should be resilient to calls to conda update.

Once this ticket is merged, I will change newinstall.sh to get rid of the current install_name_tool patch.

Note: there is a supporting pull request in boost, since we have to do the same thing to libboost_python.dylib
