### PR TITLE
Non-invasive fix for building on El Capitan with Anaconda python

### DIFF
--- a/patches/dyld_fallback_library_path.patch
+++ b/patches/dyld_fallback_library_path.patch
@@ -1,0 +1,46 @@
+--- GalSim/SConstruct	2016-03-29 14:42:32.000000000 -0700
++++ GalSim/SConstruct	2016-04-09 04:43:01.000000000 -0700
+@@ -107,6 +107,13 @@
+          'this option enables SCons to set it back in for you by doing '+
+          '`scons DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH`.',
+          '', PathVariable.PathAccept))
++opts.Add(PathVariable('DYLD_FALLBACK_LIBRARY_PATH',
++         'Set the DYLD_FALLBACK_LIBRARY_PATH inside of SCons.  '+
++         'Particularly useful on El Capitan (and later), since Apple strips out '+
++         'DYLD_FALLBACK_LIBRARY_PATH from the environment that SCons sees, so if you need it, '+
++         'this option enables SCons to set it back in for you by doing '+
++         '`scons DYLD_FALLBACK_LIBRARY_PATH=$DYLD_FALLBACK_LIBRARY_PATH`.',
++         '', PathVariable.PathAccept))
+ opts.Add('NOSETESTS','Name of nosetests executable','')
+ opts.Add(BoolVariable('CACHE_LIB','Cache the results of the library checks',True))
+ opts.Add(BoolVariable('WITH_PROF',
+@@ -691,6 +698,11 @@
+         paths=paths.split(os.pathsep)
+         AddPath(lib_paths, paths)
+ 
++    if env['IMPORT_PATHS'] and os.environ.has_key('DYLD_FALLBACK_LIBRARY_PATH'):
++        paths=os.environ['DYLD_FALLBACK_LIBRARY_PATH']
++        paths=paths.split(os.pathsep)
++        AddPath(lib_paths, paths)
++
+     env.PrependENVPath('PATH', bin_paths)
+     env.Prepend(LIBPATH= lib_paths)
+     env.Prepend(CPPPATH= cpp_paths)
+@@ -714,12 +726,11 @@
+ 
+     env is the relevant SCons environment.
+     """
+-    if 'DYLD_LIBRARY_PATH' in env and env['DYLD_LIBRARY_PATH'] != '':
+-        pre = 'DYLD_LIBRARY_PATH=%r'%env['DYLD_LIBRARY_PATH']
+-        pname = "%s %s"%(pre,pname)
+-    if 'LD_LIBRARY_PATH' in env and env['LD_LIBRARY_PATH'] != '':
+-        pre = 'LD_LIBRARY_PATH=%r'%env['LD_LIBRARY_PATH']
+-        pname = "%s %s"%(pre,pname)
++    for var in ['DYLD_LIBRARY_PATH', 'DYLD_FALLBACK_LIBRARY_PATH', 'LD_LIBRARY_PATH']:
++        if var in env and env[var] != '':
++            pre = '%s=%r'%(var,env[var])
++            pname = "%s %s"%(pre,pname)
++
+     return pname
+ 
+ def AltTryRun(config, text, extension):

--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,102 +1,70 @@
-export SCONSFLAGS=$SCONSFLAGS" USE_UNKNOWN_VARS=true TMV_DIR="$TMV_DIR" PREFIX="$PREFIX" PYPREFIX="$PREFIX"/lib/python EXTRA_LIB_PATH="$TMV_DIR"/lib EXTRA_INCLUDE_PATH="$TMV_DIR"/include"
+#export SCONSFLAGS=$SCONSFLAGS" USE_UNKNOWN_VARS=true TMV_DIR="$TMV_DIR" PREFIX="$PREFIX" PYPREFIX="$PREFIX"/lib/python EXTRA_LIB_PATH="$TMV_DIR"/lib EXTRA_INCLUDE_PATH="$TMV_DIR"/include"
+SCONSFLAGS+=" PREFIX=$PREFIX PYPREFIX=$PREFIX/lib/python"
+SCONSFLAGS+=" TMV_DIR=$TMV_DIR EXTRA_LIB_PATH=$TMV_DIR/lib EXTRA_INCLUDE_PATH=$TMV_DIR/include"
+SCONSFLAGS+=" USE_UNKNOWN_VARS=true"
+export SCONSFLAGS
 
-pythonLibDir=$(python -c "import sysconfig; print sysconfig.get_config_var('LIBDIR')")
+if [[ $OSTYPE == darwin* ]]; then
+	# Add DYLD_LIBRARY_PATH to SCONSFLAGS (deriving it from LSST_LIBRARY_PATH).
+	# This is required for OS X >=10.11 compatibility as SIP tends to wipe out
+	# DYLD_LIBRARY_PATH
+	export SCONSFLAGS+=" DYLD_LIBRARY_PATH='$LSST_LIBRARY_PATH'"
 
-pythonLib=$(python -c "import sysconfig; print sysconfig.get_config_var('LDLIBRARY')")
+	# Detect broken libpython*.dylib install name on OS X. We do this
+	# by checking whether the install name in libpython*.dylib begins
+	# with / (absolute) or @ (in which case it's most likely a @rpath).
+	# Note that $LIBPYTHON_DYLIB may not exist (e.g., if Python lib has
+	# been built as a framework -- like /usr/bin/python)
+	LIBPYTHON_DYLIB=$(python -c "import sysconfig, os.path; print os.path.join(*sysconfig.get_config_vars('LIBDIR', 'LDLIBRARY'))")
+	if [[ -f "$LIBPYTHON_DYLIB" ]]; then
+		LIBPYTHON_DYLIB_INSTNAME=$(otool -X -D "$LIBPYTHON_DYLIB")
+		if [[ ! $LIBPYTHON_DYLIB_INSTNAME =~ [/@].* ]]; then
+			BROKEN_LIBPYTHON_DYLIB=1
+		fi
+	fi
 
-pythonLibFullPath=$(python -c "import sysconfig, os; print os.path.join(sysconfig.get_config_var('LIBDIR'), sysconfig.get_config_var('LDLIBRARY'))")
-
-export DYLD_FALLBACK_LIBRARY_PATH="$pythonLibDir"
-
-galsim_build_failure(){
-    # Print an explanatory message of the install fails while
-    # trying to apply the install_name_tool fix to libpython2.7.dylib
-    #
-    # $1 should be a string indicating the nature of the failure:
-    # 'usr' if the build failed because libpython2.7.dylib appears
-    #       to be in /usr/
-    #  'install_name_tool' if the build failed when trying to run
-    #       install_name_tool in libpython2.7.dylib
-
-    echo " "
-    echo "NOTE FROM LSST: this probably will not work"
-    echo "It appears that your "$pythonLib" does not have"
-    echo "a correct loader path."
-    echo " "
-
-    if [[ $1 == "usr" ]]; then
-        echo "Unfortunately, the "$pythonLib" you are"
-        echo "building against appears to be in /usr/, so the"
-        echo "eups distrib automatic build system is not going"
-        echo "to try to fix it."
-
-    elif [[ $1 == "install_name_tool" ]]; then
-        echo "Unfortunately, attempting to run install_name_tool"
-        echo "on the "$pythonLib" against which you are building"
-        echo "failed.  You may not have adequate permissions"
-
-    else
-        echo "It is unclear what the problem is,"
-        echo "but the eups distrib automatic build system cannot"
-        echo "fix the loader path."
-    fi
-
-    echo " "
-    echo "FYI: you are trying to build against"
-    echo $pythonLibFullPath
-    echo " "
-
-    echo "We will proceed with the build.  If it fails"
-    echo "on GalSim, try consulting"
-    echo "http://stackoverflow.com/questions/23771608/trouble-installing-galsim-on-osx-with-anaconda"
-    echo "for a likely fix."
-    echo " "
-}
+	if [[ $BROKEN_LIBPYTHON_DYLIB = 1 ]]; then
+		# Add the Python library directory to GalSim's DYLD_FALLBACK_LIBRARY_PATH, to enable
+		# the build to pass successfully. We'll patch the resultant _galsim.so in the build() phase,
+		# enabling it to find the correct libpython*.dylib w/o the ened to set DYLD_FALLBACK_LIBRARY_PATH
+		# at runtime
+		DYLD_FALLBACK_LIBRARY_PATH=$(python -c "import sysconfig; print sysconfig.get_config_var('LIBDIR')")
+		export SCONSFLAGS+=" DYLD_FALLBACK_LIBRARY_PATH='$DYLD_FALLBACK_LIBRARY_PATH'"
+	fi
+fi
 
 build()
 {
+	if [[ ! -z $LIBPYTHON_DYLIB ]]; then
+		echo "LIBPYTHON_DYLIB=$LIBPYTHON_DYLIB"
+		echo "LIBPYTHON_DYLIB_INSTNAME=$LIBPYTHON_DYLIB_INSTNAME"
+		echo "BROKEN_LIBPYTHON_DYLIB=$BROKEN_LIBPYTHON_DYLIB"
+	fi
 
-    # test to see if we are running on OSX
-    if [[ $OSTYPE == darwin* ]]; then
-        version=${OSTYPE#darwin}
+	default_build
 
-        # now, test to see if we are in El Capitan (or later)
-        if [[ $version -ge 15 ]]; then
+	if [[ $BROKEN_LIBPYTHON_DYLIB ]]; then
+		#
+		# Fix the path to libpython*.dylib, as stored in _galsim.so, so that it can
+		# find the correct Python library even if it's not on DYLD_LIBRARY_PATH at
+		# runtime. We also need to define the @rpath; we hach this a little, by
+		# assuming the library directory is in ../lib relative to where the Python
+		# executable lives.
+		#
+		GALSIM_SO="galsim/_galsim.so"
 
-            # now investigate whether the libpython2.7.dylib has an appropriate
-            # loader address
-
-            selfAddress=$(otool -D "$pythonLibFullPath")
-            selfAddressStripped=$(echo "${selfAddress#$pythonLibFullPath:}" | tr -d [:space:])
-
-            if [[ $selfAddressStripped == $pythonLib ]]; then
-
-                if [[ $pythonLibFullPath == *"/usr/"* ]]; then
-
-                    # we are using a library in /usr/
-                    # we will not try to fix it
-
-                    galsim_build_failure "usr"
-
-                else
-                    install_name_tool -id @rpath/"$pythonLib" "$pythonLibFullPath" \
-                    || galsim_build_failure "install_name_tool"
-                fi
-            fi
-        fi
-    fi
-
-    scons DYLD_LIBRARY_PATH="$LSST_LIBRARY_PATH" DYLD_FALLBACK_LIBRARY_PATH="$DYLD_FALLBACK_LIBRARY_PATH" -j$NJOBS prefix="$PREFIX" version="$VERSION" cc="$CC"
-
+		install_name_tool -change "$LIBPYTHON_DYLIB_INSTNAME" "@rpath/$LIBPYTHON_DYLIB_INSTNAME" "$GALSIM_SO"
+		install_name_tool -add_rpath                          "@executable_path/../lib"          "$GALSIM_SO"
+		
+		echo "Patching linker information in $GALSIM_SO:"
+		otool -L "$GALSIM_SO"
+		echo "done."
+	fi
 }
 
 install()
 {
-    default_install
-    cp -r include $PREFIX/
+	default_install
 
-    if [[ $OSTYPE == darwin* ]]; then
-        install_name_tool -add_rpath "$DYLD_FALLBACK_LIBRARY_PATH" "$PREFIX"/lib/python/galsim/_galsim.so
-        install_name_tool -change "$pythonLib" @rpath/"$pythonLib" "$PREFIX"/lib/python/galsim/_galsim.so
-    fi
+	cp -r include "$PREFIX/"
 }


### PR DESCRIPTION
Detect if the libpython*.dylib library's install_name is incorrect
(relative), and:
- pass DYLD_FALLBACK_LIBRARY_PATH to GalSim's scons, to enable the build to proceed
- fix the install_name in _galsim.so after the build succeeds.

This enables us to work around Anaconda Python's bug described in https://github.com/ContinuumIO/anaconda-issues/issues/498 and successfully build+run GalSim.
