### PR TITLE
[DM-7449] Add explicit dependency to python_future.

### DIFF
--- a/ups/galsim.table
+++ b/ups/galsim.table
@@ -1,5 +1,6 @@
 setupRequired(numpy)
 setupRequired(pyfits)
+setupRequired(python_future)
 setupRequired(boost)
 setupRequired(fftw)
 setupRequired(tmv)


### PR DESCRIPTION
Since the eups python_future package exists and is already used, galsim should use this approach too. Otherwise it's a one off case and breaks conda-lsst builds.
    modified:   ups/galsim.table
