### PR TITLE
DM-12693: Add upstream fix for linking problem with modern miniconda

### DIFF
--- a/patches/0003-fix-anaconda-linking.patch
+++ b/patches/0003-fix-anaconda-linking.patch
@@ -1,0 +1,20 @@
+diff --git a/SConstruct.orig b/SConstruct
+index 2538aba..357b954 100644
+--- a/SConstruct.orig
++++ b/SConstruct
+@@ -1210,5 +1210,15 @@
+     config.Message('Checking if we can build against Python... ')
+
++    # Check if we need to add any additional linking flags according to what is given in
++    # sysconfig.get_config_var("LDSHARED").  cf. Issue #924
++    sys_builder = distutils.sysconfig.get_config_var("LDSHARED")
++    ldflags = sys_builder.split()
++    ldflags = ldflags[1:]  # strip off initial gcc or cc
++    config.env.Replace(LDMODULEFLAGS=['$LINKFLAGS'] + ldflags)
++    # Need this too to get consistency, e.g. with --arch options.
++    ccflags = distutils.sysconfig.get_config_var("CCSHARED")
++    config.env.Append(CCFLAGS=ccflags.split())
++
+     # First check the python include directory -- see if we can compile the module.
+     source_file2 = "import distutils.sysconfig; print(distutils.sysconfig.get_python_inc())"
+     result, py_inc = TryScript(config,source_file2,python)


### PR DESCRIPTION
This patch comes from GalSim-developers/GalSim#927 and does fix my problem.